### PR TITLE
Fixed Vulnerabilities 

### DIFF
--- a/qtwebengine/src/3rdparty/chromium/third_party/libpng/pngpread.c
+++ b/qtwebengine/src/3rdparty/chromium/third_party/libpng/pngpread.c
@@ -224,6 +224,21 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
          png_benign_error(png_ptr, "Too many IDATs found");
    }
 
+    else
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (png_ptr->push_length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+   
    if (chunk_name == png_IHDR)
    {
       if (png_ptr->push_length != 13)

--- a/qtwebengine/src/3rdparty/chromium/third_party/libpng/pngrutil.c
+++ b/qtwebengine/src/3rdparty/chromium/third_party/libpng/pngrutil.c
@@ -182,8 +182,22 @@ png_read_chunk_header(png_structrp png_ptr)
    png_check_chunk_name(png_ptr, png_ptr->chunk_name);
 
    /* Check for too-large chunk length */
-   png_check_chunk_length(png_ptr, length);
-
+   if (png_ptr->chunk_name != png_IDAT)
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+   
+   
 #ifdef PNG_IO_STATE_SUPPORTED
    png_ptr->io_state = PNG_IO_READING | PNG_IO_CHUNK_DATA;
 #endif

--- a/qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/libpng16/pngpread.c
+++ b/qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/libpng16/pngpread.c
@@ -223,7 +223,23 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
       if ((png_ptr->mode & PNG_AFTER_IDAT) != 0)
          png_benign_error(png_ptr, "Too many IDATs found");
    }
-
+   
+   else
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (png_ptr->push_length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+   
+   
    if (chunk_name == png_IHDR)
    {
       if (png_ptr->push_length != 13)

--- a/qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/libpng16/pngrutil.c
+++ b/qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/libpng16/pngrutil.c
@@ -182,8 +182,22 @@ png_read_chunk_header(png_structrp png_ptr)
    png_check_chunk_name(png_ptr, png_ptr->chunk_name);
 
    /* Check for too-large chunk length */
-   png_check_chunk_length(png_ptr, length);
-
+ if (png_ptr->chunk_name != png_IDAT)
+   {
+      png_alloc_size_t limit = PNG_SIZE_MAX;
+# ifdef PNG_SET_USER_LIMITS_SUPPORTED
+      if (png_ptr->user_chunk_malloc_max > 0 &&
+          png_ptr->user_chunk_malloc_max < limit)
+         limit = png_ptr->user_chunk_malloc_max;
+# elif PNG_USER_CHUNK_MALLOC_MAX > 0
+      if (PNG_USER_CHUNK_MALLOC_MAX < limit)
+         limit = PNG_USER_CHUNK_MALLOC_MAX;
+# endif
+      if (length > limit)
+         png_chunk_error(png_ptr, "chunk data is too large");
+   }
+   
+   
 #ifdef PNG_IO_STATE_SUPPORTED
    png_ptr->io_state = PNG_IO_READING | PNG_IO_CHUNK_DATA;
 #endif


### PR DESCRIPTION
Fixed vulnerabilities in files pngpread.c and pngrutil.c in the following paths: 
qtwebengine/src/3rdparty/chromium/third_party/libpng/pngpread.c and pngrutil.c
qtwebengine/src/3rdparty/chromium/third_party/pdfium/third_party/libpng16/pngpread.c and pngrutil.c

libpng is a popular graphics library.
libpng is subject to CVE-2017-12652.
The vulnerability was fixed by commit 347538efbdc21b8df684ebd92d37400b3ce85d55.
The fix is in two files: pngpread.c and pngrutil.c.

https://github.com/glennrp/libpng/commit/347538efbdc21b8df684ebd92d37400b3ce85d55 